### PR TITLE
Remove ambiguous Label parameters

### DIFF
--- a/Tests/ConfluencePS.Integration.Tests.ps1
+++ b/Tests/ConfluencePS.Integration.Tests.ps1
@@ -414,7 +414,7 @@ InModuleScope ConfluencePS {
         # ARRANGE
         $SpaceKey = "PESTER"
         $Page1 = Get-WikiPage -Title "Pester New Page Piped" -ErrorAction Stop
-        $Label1 = @("pestera", "pesterb", "pesterc")
+        $Label1 = [string[]]("pestera", "pesterb", "pesterc")
         $Label2 = "pesterall"
         $PartialLabel = "pest"
 


### PR DESCRIPTION
Remove ambiguous `-Labels` parameters from `Add-WikiLabel`.

Added parameter validation, as no type hinting is possible

fixes #52 